### PR TITLE
Enhanced documentation wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@ Project homepage: [https://github.com/iamluc/docker-hostmanager](https://github.
 The easiest way is to use the docker image
 
 ```console
-$ docker run -d --name docker-hostmanager -v /var/run/docker.sock:/var/run/docker.sock -v /etc/hosts:/hosts iamluc/docker-hostmanager
+$ docker run -d --name docker-hostmanager --restart=always -v /var/run/docker.sock:/var/run/docker.sock -v /etc/hosts:/hosts iamluc/docker-hostmanager
 ```
 
-*TIPS*
-
-To start automatically your container with your computer, add the option `--restart=always`
+*Note: the `--restart=always` option will make the container start automatically with your computer (recommended).*
 
 #### Mac OS
 


### PR DESCRIPTION
Not being used to Docker might make one put the `--restart=always` option at the end of given command line, which would not work. This wording makes things clearer IMHO.

Kudos for the tool! :)
