### PR TITLE
merge hosts with same ip onto one line in hosts file

### DIFF
--- a/src/Synchronizer.php
+++ b/src/Synchronizer.php
@@ -136,32 +136,15 @@ class Synchronizer
                     $hosts[] = $alias.'.'.$networkName;
                 }
 
-                if (isset($lines[$ip])) {
-                    $lines[$ip] .= ' ';
-                } else {
-                    $lines[$ip] = '';
-                }
-
-                $lines[$ip] .= implode(' ', $hosts);
+                $lines[$ip] = sprintf('%s%s', isset($lines[$ip]) ? $lines[$ip].' ' : '', implode(' ', $hosts));
             }
         }
 
-        return $this->mergeLines($lines);
-    }
+        array_walk($lines, function (&$host, $ip) {
+            $host = $ip.' '.$host;
+        });
 
-    /**
-     * @param array $lines
-     *
-     * @return array
-     */
-    public function mergeLines(array $lines)
-    {
-        $mergedLines = [];
-        foreach ($lines as $ip => $line) {
-            $mergedLines[] = $ip.' '.$line;
-        }
-
-        return $mergedLines;
+        return $lines;
     }
 
     /**

--- a/src/Synchronizer.php
+++ b/src/Synchronizer.php
@@ -120,7 +120,7 @@ class Synchronizer
         if (!empty($inspection['NetworkSettings']['IPAddress'])) {
             $ip = $inspection['NetworkSettings']['IPAddress'];
 
-            $lines[] = $ip.' '.implode(' ', $this->getContainerHosts($container));
+            $lines[$ip] = implode(' ', $this->getContainerHosts($container));
         }
 
         // Networks
@@ -136,11 +136,32 @@ class Synchronizer
                     $hosts[] = $alias.'.'.$networkName;
                 }
 
-                $lines[] = $ip.' '.implode(' ', $hosts);
+                if (isset($lines[$ip])) {
+                    $lines[$ip] .= ' ';
+                } else {
+                    $lines[$ip] = '';
+                }
+
+                $lines[$ip] .= implode(' ', $hosts);
             }
         }
 
-        return $lines;
+        return $this->mergeLines($lines);
+    }
+
+    /**
+     * @param array $lines
+     *
+     * @return array
+     */
+    public function mergeLines(array $lines)
+    {
+        $mergedLines = [];
+        foreach ($lines as $ip => $line) {
+            $mergedLines[] = $ip.' '.$line;
+        }
+
+        return $mergedLines;
     }
 
     /**


### PR DESCRIPTION
Currently, it is possible that the same ip adress is twice in the host file:

```
172.1.2.3 app.docker
172.1.2.3 app.bridge
```

This PR propose to have only one line per IP:

```
172.1.2.3 app.docker app.bridge
```
