### PR TITLE
merge hosts with same ip onto one line in hosts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@ Project homepage: [https://github.com/iamluc/docker-hostmanager](https://github.
 The easiest way is to use the docker image
 
 ```console
-$ docker run -d --name docker-hostmanager -v /var/run/docker.sock:/var/run/docker.sock -v /etc/hosts:/hosts iamluc/docker-hostmanager
+$ docker run -d --name docker-hostmanager --restart=always -v /var/run/docker.sock:/var/run/docker.sock -v /etc/hosts:/hosts iamluc/docker-hostmanager
 ```
 
-*TIPS*
-
-To start automatically your container with your computer, add the option `--restart=always`
+*Note: the `--restart=always` option will make the container start automatically with your computer (recommended).*
 
 #### Mac OS
 

--- a/src/Synchronizer.php
+++ b/src/Synchronizer.php
@@ -120,7 +120,7 @@ class Synchronizer
         if (!empty($inspection['NetworkSettings']['IPAddress'])) {
             $ip = $inspection['NetworkSettings']['IPAddress'];
 
-            $lines[] = $ip.' '.implode(' ', $this->getContainerHosts($container));
+            $lines[$ip] = implode(' ', $this->getContainerHosts($container));
         }
 
         // Networks
@@ -136,9 +136,13 @@ class Synchronizer
                     $hosts[] = $alias.'.'.$networkName;
                 }
 
-                $lines[] = $ip.' '.implode(' ', $hosts);
+                $lines[$ip] = sprintf('%s%s', isset($lines[$ip]) ? $lines[$ip].' ' : '', implode(' ', $hosts));
             }
         }
+
+        array_walk($lines, function (&$host, $ip) {
+            $host = $ip.' '.$host;
+        });
 
         return $lines;
     }


### PR DESCRIPTION
Currently, it is possible that the same ip adress is twice in the host file:

```
172.1.2.3 app.docker
172.1.2.3 app.bridge
```

This PR propose to have only one line per IP:

``````
172.1.2.3 app.docker app.bridge```
``````
