### PR TITLE
Add DOMAIN_NAME for networks

### DIFF
--- a/src/Synchronizer.php
+++ b/src/Synchronizer.php
@@ -127,7 +127,7 @@ class Synchronizer
         if (isset($container['NetworkSettings']['Networks']) && is_array($container['NetworkSettings']['Networks'])) {
             foreach ($container['NetworkSettings']['Networks'] as $networkName => $conf) {
                 preg_match(sprintf('/^%s_(.+)$/', $this->getProjectName($container)), $networkName, $matches);
-                $networkShortName = $matches[1];
+                $networkShortName = isset($matches[1]) ? $matches[1] : null;
                 $ip = $conf['IPAddress'];
 
                 $aliases = isset($conf['Aliases']) && is_array($conf['Aliases']) ? $conf['Aliases'] : [];

--- a/src/Synchronizer.php
+++ b/src/Synchronizer.php
@@ -178,7 +178,7 @@ class Synchronizer
     {
         return array_merge(
             [substr($container['Name'], 1).$this->tld],
-            $this->getAdditionalHosts($container)
+            $this->getAdditionalContainerHosts($container)
         );
     }
 

--- a/src/Synchronizer.php
+++ b/src/Synchronizer.php
@@ -126,6 +126,8 @@ class Synchronizer
         // Networks
         if (isset($container['NetworkSettings']['Networks']) && is_array($container['NetworkSettings']['Networks'])) {
             foreach ($container['NetworkSettings']['Networks'] as $networkName => $conf) {
+                preg_match(sprintf('/^%s_(.+)$/', $this->getProjectName($container)), $networkName, $matches);
+                $networkShortName = $matches[1];
                 $ip = $conf['IPAddress'];
 
                 $aliases = isset($conf['Aliases']) && is_array($conf['Aliases']) ? $conf['Aliases'] : [];
@@ -134,6 +136,12 @@ class Synchronizer
                 $hosts = [];
                 foreach (array_unique($aliases) as $alias) {
                     $hosts[] = $alias.'.'.$networkName;
+                }
+
+                foreach ($this->getAdditionalContainerHosts($container) as $host) {
+                    if (preg_match('/^(.+):(.+)$/', $host, $matches) && $matches[1] === $networkShortName) {
+                        $hosts[] = $matches[2];
+                    }
                 }
 
                 $lines[$ip] = sprintf('%s%s', isset($lines[$ip]) ? $lines[$ip].' ' : '', implode(' ', $hosts));
@@ -148,22 +156,67 @@ class Synchronizer
     }
 
     /**
-     * @param Container $container
+     * @param array $container
+     *
+     * @return string
+     */
+    private function getProjectName($container)
+    {
+        if (isset($container['Config']['Labels']['com.docker.compose.project'])) {
+            return $container['Config']['Labels']['com.docker.compose.project'];
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array $container
      *
      * @return array
      */
     private function getContainerHosts($container)
     {
-        $hosts = [substr($container['Name'], 1).$this->tld];
-        if (isset($container['Config']['Env']) && is_array($container['Config']['Env'])) {
-            $env = $container['Config']['Env'];
-            foreach (preg_grep('/DOMAIN_NAME=/', $env) as $row) {
-                $row = substr($row, strlen('DOMAIN_NAME='));
-                $hosts = array_merge($hosts, explode(',', $row));
-            }
+        return array_merge(
+            [substr($container['Name'], 1).$this->tld],
+            $this->getAdditionalHosts($container)
+        );
+    }
+
+    /**
+     * @param array $container
+     *
+     * @return array
+     */
+    private function getAdditionalContainerHosts($container)
+    {
+        $hosts = [];
+
+        $domainName = $this->getEnv($container, 'DOMAIN_NAME');
+        if ($domainName) {
+            $hosts = array_merge($hosts, explode(',', $domainName));
         }
 
         return $hosts;
+    }
+
+    /**
+     * @param array  $container
+     * @param string $name
+     * @param string $default
+     *
+     * @return string
+     */
+    private function getEnv($container, $name, $default = null)
+    {
+        if (isset($container['Config']['Env']) && is_array($container['Config']['Env'])) {
+            foreach ($container['Config']['Env'] as $env) {
+                if (preg_match(sprintf('/^%s=(.*)$/', $name), $env, $matches)) {
+                    return $matches[1];
+                }
+            }
+        }
+
+        return $default;
     }
 
     /**


### PR DESCRIPTION
Resolves #32 

Add the possibility to add a DOMAIN_NAME for containers in a network. To specify the network concerned by the domain name, add `my_network_name:` before value. Exemple :
```
version: '2'

networks:
  first:
    driver: bridge
  second:
    driver: bridge

services:
  web:
    image: php:7-apache
    environment:
      - "DOMAIN_NAME=first:web,first:www.web"
    networks:
      - first
      - second
  db:
    image: php:7-apache
    environment:
      - "DOMAIN_NAME=first:db,second:database"
    networks:
      - first
      - second
  mail:
    image: php:7-apache
    environment:
      - "DOMAIN_NAME=first:mail"
    networks:
      - first
```
will result in
```
## docker-hostmanager-start
172.26.0.4 ... db.dockerhostmanager_first db
172.25.0.3 ... db.dockerhostmanager_second database
172.26.0.3 ... web.dockerhostmanager_first web www.web
172.25.0.2 ... web.dockerhostmanager_second
172.26.0.2 ... mail.dockerhostmanager_first mail
## docker-hostmanager-end
```