### PR TITLE
 Fix routing to only include private IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ docker run -d --name docker-hostmanager --restart=always -v /var/run/docker.so
 After run the container we need to add a route to access container subnets.
 
 ```
-$ route /P add 172.17.0.0/8 192.168.99.100
+$ route /P add 172.17.0.0/12 192.168.99.100
 ```
 
 ### CONFIGURATION


### PR DESCRIPTION
Previously the README suggested to route all traffic from `172.0.0.0/8` to the Mac docker-machine. 

However, this includes public IP, as the reserved range for the private IPs is `172.0.0.0/12` 
(see [the Wikipedia page](https://en.wikipedia.org/wiki/Private_network#Private_IPv4_addresses))

For example, on my machine, google.com translated to 172.14.x.x, meaning google.com was unreachable using the route suggested in the README