### PR TITLE
Github Actions that builds linux/amd64 and linux/arm64

### DIFF
--- a/.github/workflows/DockerHub.yml
+++ b/.github/workflows/DockerHub.yml
@@ -1,0 +1,23 @@
+name: Build and Push Docker images to Docker Hub
+
+on: push
+jobs:
+  build_linux_amd64:
+    name: Build linux/amd64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-hostname:0.0.1

--- a/.github/workflows/DockerHub.yml
+++ b/.github/workflows/DockerHub.yml
@@ -2,22 +2,24 @@ name: Build and Push Docker images to Docker Hub
 
 on: push
 jobs:
-  build_linux_amd64:
-    name: Build linux/amd64
+  build_job:
+    name: Build and push
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
-      - name: Build and push Docker image
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-hostname:0.0.1
+
+      - name: Run Buildx and push image
+        run: |
+          docker buildx create --use --name multi-arch-builder --platform "linux/arm64,linux/amd64"
+          docker buildx build --platform "linux/arm64,linux/amd64" --tag ${{ secrets.DOCKERHUB_USERNAME }}/docker-hostmanager:0.0.4 --file Dockerfile --output type=image,push=true .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM iamluc/composer
+FROM composer:1.4.3
 
 ADD . /usr/local/src/docker-hostmanager
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "iamluc/docker-hostmanager",
     "license": "MIT",
+    "version": "0.0.1",
     "type": "project",
     "description": "Update /etc/hosts to access running containers",
     "keywords": ["docker", "hosts"],

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "iamluc/docker-hostmanager",
     "license": "MIT",
-    "version": "0.0.1",
+    "version": "0.0.4",
     "type": "project",
     "description": "Update /etc/hosts to access running containers",
     "keywords": ["docker", "hosts"],


### PR DESCRIPTION
Hi,
I was able to create a basic setup action that builds images for linux/amd64 and linux/arm64 and pushes to Docker Hub.

I followed this video to create a initial setup just for linux/amd64  
https://www.youtube.com/watch?v=J5GP1WNKyeo

Then, after some try and errors, I found this article that explains how to use Buildx to build multiple architectures at once:  
https://ruanbekker.medium.com/how-to-create-arm-based-container-images-with-buildx-fe917d186824

I changed the Dockerfile to use official composer image, and I put it to use version 1.4.3 because the latest composer needs php 8.3 but this project has a dependency with limitation to php 7.0.  
I used 1.4.3 because it was the first with linux/arm64 support. If you update your project to use php 8, then you could update composer to latest.  

I am using it on my Raspberry Pi 5 arm64 (bookworm).  

Let me know if you have any questions.  

Bruno